### PR TITLE
Remove safeexec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/bep/godartsass/v2
 go 1.23
 
 require (
-	github.com/cli/safeexec v1.0.1
 	github.com/frankban/quicktest v1.14.2
 	google.golang.org/protobuf v1.35.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
-github.com/cli/safeexec v1.0.1/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/frankban/quicktest v1.14.2 h1:SPb1KFFmM+ybpEjPUhCCkZOM5xlovT5UbrMvWnXyBns=
 github.com/frankban/quicktest v1.14.2/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=

--- a/transpiler.go
+++ b/transpiler.go
@@ -21,8 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cli/safeexec"
-
 	"github.com/bep/godartsass/v2/internal/embeddedsass"
 	"github.com/bep/godartsass/v2/internal/godartsasstesting"
 	"google.golang.org/protobuf/proto"
@@ -47,7 +45,7 @@ func Start(opts Options) (*Transpiler, error) {
 	}
 
 	// See https://github.com/golang/go/issues/38736
-	bin, err := safeexec.LookPath(opts.DartSassEmbeddedFilename)
+	bin, err := exec.LookPath(opts.DartSassEmbeddedFilename)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +79,7 @@ func Start(opts Options) (*Transpiler, error) {
 // in dartSassEmbeddedFilename.
 func Version(dartSassEmbeddedFilename string) (DartSassVersion, error) {
 	var v DartSassVersion
-	bin, err := safeexec.LookPath(dartSassEmbeddedFilename)
+	bin, err := exec.LookPath(dartSassEmbeddedFilename)
 	if err != nil {
 		return v, err
 	}


### PR DESCRIPTION
The vulnerability was addressed by the Go team in 1.19, so the safeexec package is no longer needed.
