### PR TITLE
Update Go 1.25.x/1.26.x, GitHub Actions, go.mod Go 1.25, dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bep/godartsass/v2
 
-go 1.24
+go 1.25
 
 require (
 	github.com/frankban/quicktest v1.14.6


### PR DESCRIPTION
Updates: Go 1.25.x/1.26.x, GitHub Actions, go.mod Go 1.25, dependencies

---
Created by mygithelper